### PR TITLE
Lisbn.extract()

### DIFF
--- a/lib/lisbn/lisbn.rb
+++ b/lib/lisbn/lisbn.rb
@@ -1,4 +1,13 @@
 class Lisbn < String
+
+  # Find an ISBN in a string of text
+  def self.extract(string)
+    string.scan(/([\dX-]{10,18})/i).flatten.map do |match|
+      isbn = new(match)
+      isbn.valid? ? isbn : nil
+    end.compact
+  end
+
   # Returns a normalized ISBN form
   def isbn
     upcase.gsub(/[^0-9X]/, '')

--- a/lib/lisbn/lisbn.rb
+++ b/lib/lisbn/lisbn.rb
@@ -1,10 +1,18 @@
 class Lisbn < String
 
   # Find an ISBN in a string of text
-  def self.extract(string)
-    string.scan(/([\dX-]{10,18})/i).flatten.map do |match|
-      isbn = new(match)
-      isbn.valid? ? isbn : nil
+  def scan_isbns
+    scan(/([\dX-]{10,})/i).flatten.map do |match|
+      isbn = self.class.new(match)
+      if isbn.valid?
+        if block_given?
+          yield isbn
+        else
+          isbn
+        end
+      else
+        nil
+      end
     end.compact
   end
 

--- a/lisbn.gemspec
+++ b/lisbn.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "0.1.3"
 
-  gem.add_dependency "nori", "~> 2.0"
+  gem.add_dependency "nori", "~> 2.3"
   gem.add_dependency "nokogiri"
   gem.add_development_dependency "rspec"
 end

--- a/lisbn.gemspec
+++ b/lisbn.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "0.1.3"
 
-  gem.add_dependency "nori", "~> 2.3"
+  gem.add_dependency "nori", "~> 2.0"
   gem.add_dependency "nokogiri"
   gem.add_development_dependency "rspec"
 end

--- a/spec/lisbn_spec.rb
+++ b/spec/lisbn_spec.rb
@@ -133,17 +133,26 @@ describe "Lisbn" do
     end
   end
 
-  describe ".extract" do
+  describe "#scan_isbns" do
     it "should find two ISBN-13s in this sentence and return an array" do
-      isbns = Lisbn.extract("Hi, I'm looking for 9780000000002 or 978-601-7002-01-5.")
-      isbns.should be_kind_of(Array)
+      isbns = Lisbn.new("Hi, I'm looking for 9780000000002 or 978-601-7002-01-5.").scan_isbns
+      isbns.should be_kind_of Array
       isbns.size.should == 2
       isbns[0].should == "9780000000002"
       isbns[1].isbn.should == "9786017002015"
     end
 
-    it "should return an empty array" do
-      Lisbn.extract("nothing to see here").should == []
+    it "should take a block" do
+      isbns = 0
+      Lisbn.new("Hi, I'm looking for 9780000000002 or 978-601-7002-01-5.").scan_isbns do |isbn|
+        isbn.should be_kind_of Lisbn
+        isbns += 1
+      end
+      isbns.should == 2
+    end
+
+    it "should return an empty array when no ISBNs are present" do
+      Lisbn.new("nothing to see here").scan_isbns.should == []
     end
   end
 

--- a/spec/lisbn_spec.rb
+++ b/spec/lisbn_spec.rb
@@ -132,4 +132,19 @@ describe "Lisbn" do
       subject.split("7").should == ["9", "80000000002"]
     end
   end
+
+  describe ".extract" do
+    it "should find two ISBN-13s in this sentence and return an array" do
+      isbns = Lisbn.extract("Hi, I'm looking for 9780000000002 or 978-601-7002-01-5.")
+      isbns.should be_kind_of(Array)
+      isbns.size.should == 2
+      isbns[0].should == "9780000000002"
+      isbns[1].isbn.should == "9786017002015"
+    end
+
+    it "should return an empty array" do
+      Lisbn.extract("nothing to see here").should == []
+    end
+  end
+
 end


### PR DESCRIPTION
This adds a helper method to find valid ISBNs within blocks of text.

``` ruby
Lisbn.extract("Long form text mentioning several ISBNs including 978-0-07-352550-1") #=> ["978-0-07-352550-1"]
```
